### PR TITLE
feat: add and comment out the replica readonly new db

### DIFF
--- a/database/terraform/database.tf
+++ b/database/terraform/database.tf
@@ -45,12 +45,13 @@ resource "digitalocean_database_firewall" "treetracker-database-fw" {
   }
 }
 
-resource "digitalocean_database_replica" "treetracker-postgres-read-replica" {
-  cluster_id = digitalocean_database_cluster.treetracker-postgres-cluster.id
-  name       = "read-replica"
-  size       = "db-s-2vcpu-4gb"
-  region     = "nyc1"
-}
+#resource "digitalocean_database_replica" "treetracker-postgres-read-replica" {
+#  cluster_id = digitalocean_database_cluster.treetracker-postgres-cluster.id
+#  name       = "read-replica"
+#  size       = "db-s-4vcpu-8gb"
+#  region     = "nyc1"
+#  tags       = ["foresmatic"]
+#}
 
 #resource "digitalocean_database_replica_firewall" "treetracker-database-replica-fw" {
 #  cluster_id = digitalocean_database_replica.treetracker-postgres-read-replica.id
@@ -76,13 +77,13 @@ resource "digitalocean_database_db" "ckan-database" {
   name       = "ckan"
 }
 
-resource "digitalocean_database_db" "ckan-datastore-database" {
-  cluster_id = digitalocean_database_cluster.treetracker-postgres-cluster.id
-  name       = "ckan_datastore"
-}
-
-resource "digitalocean_database_db" "world-bank-backup-database" {
-  cluster_id = digitalocean_database_cluster.treetracker-postgres-cluster.id
-  name       = "world_bank_backup"
-}
+#resource "digitalocean_database_db" "ckan-datastore-database" {
+#  cluster_id = digitalocean_database_cluster.treetracker-postgres-cluster.id
+#  name       = "ckan_datastore"
+#}
+#
+#resource "digitalocean_database_db" "world-bank-backup-database" {
+#  cluster_id = digitalocean_database_cluster.treetracker-postgres-cluster.id
+#  name       = "world_bank_backup"
+#}
 


### PR DESCRIPTION
DONT MERGE THIS

After upgraded the replica read-only node for the DB, there are some problems in the terraform:

1. The treetracker-postgres-read-replica has been, but the CLI failures with error shown below, but actually the readonly node has been created correctly (shows up in the panel), and if we execute plan/apply again, the terrforma will still try to create it but throws error when applying
2. The two db: world_bank_backup, ckan_storage is already in the DB, but terrforma is trying to create it, but will fails when applying



```
│ Error: Error creating DatabaseReplica: POST https://api.digitalocean.com/v2/databases/45bface0-997a-49c4-98b2-b2
76e30eaf8a/replicas: 422 (request "b752095b-6950-49f2-85fc-11e55661cb63") cluster name is not available
│
│   with digitalocean_database_replica.treetracker-postgres-read-replica,
│   on database.tf line 48, in resource "digitalocean_database_replica" "treetracker-postgres-read-replica":
│   48: resource "digitalocean_database_replica" "treetracker-postgres-read-replica" {

```