### PR TITLE
add pre-commit hooks for scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,11 @@
 default_stages: [commit]
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.71.0
     hooks:

--- a/api_gateway/terraform/environments/development/setup_keys.sh
+++ b/api_gateway/terraform/environments/development/setup_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/api_gateway/terraform/environments/production/setup_keys.sh
+++ b/api_gateway/terraform/environments/production/setup_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/api_gateway/terraform/setup_keys.sh
+++ b/api_gateway/terraform/setup_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/aws_access/terraform/setup_keys.sh
+++ b/aws_access/terraform/setup_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/database-grants/terraform/dev/get-db-password.sh
+++ b/database-grants/terraform/dev/get-db-password.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 doctl auth switch --context development
 #doctl database list 
 ID=397700c8-6591-4a27-8d65-50af5c9a0263

--- a/database-grants/terraform/dev/setup_keys.sh
+++ b/database-grants/terraform/dev/setup_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/database-grants/terraform/prod/scripts/setup_keys.sh
+++ b/database-grants/terraform/prod/scripts/setup_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/database-grants/terraform/test/setup_keys.sh
+++ b/database-grants/terraform/test/setup_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/database/terraform/setup_keys.sh
+++ b/database/terraform/setup_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/kubernetes/terraform/dev/setup_keys.sh
+++ b/kubernetes/terraform/dev/setup_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/kubernetes/terraform/import.sh
+++ b/kubernetes/terraform/import.sh
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 terraform import -var-file=dev.env.tfvars digitalocean_kubernetes_cluster.kubernetes-cluster a949ce4d-8fdd-402b-82c1-a38e47deb4cc

--- a/kubernetes/terraform/prod/setup_keys.sh
+++ b/kubernetes/terraform/prod/setup_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/kubernetes/terraform/test/setup_keys.sh
+++ b/kubernetes/terraform/test/setup_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/monitoring/roles/elasticsearch/cleanup.sh
+++ b/monitoring/roles/elasticsearch/cleanup.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/sh
+
 helm uninstall elasticsearch
 helm uninstall elasticsearch-exporter
 helm uninstall kibana

--- a/monitoring/terraform/setup_keys.sh
+++ b/monitoring/terraform/setup_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/rabbitmq/deployment/deploy-dev.sh
+++ b/rabbitmq/deployment/deploy-dev.sh
@@ -1,2 +1,4 @@
+#!/bin/sh
+
 kubectl config use-context do-sfo2-dev-k8s-treetracker
 kustomize build overlays/dev | kubectl apply -n rabbitmq-cluster --wait -f -

--- a/rabbitmq/deployment/deploy-prod.sh
+++ b/rabbitmq/deployment/deploy-prod.sh
@@ -1,2 +1,4 @@
+#!/bin/sh
+
 kubectl config use-context do-nyc1-treetracker-cluster-production
 kustomize build overlays/prod | kubectl apply -n rabbitmq-cluster --wait -f -

--- a/rabbitmq/deployment/deploy-test.sh
+++ b/rabbitmq/deployment/deploy-test.sh
@@ -1,2 +1,4 @@
+#!/bin/sh
+
 kubectl config use-context do-sfo2-test-k8s-treetracker
 kustomize build overlays/test | kubectl apply -n rabbitmq-cluster --wait -f -

--- a/rabbitmq/expose/expose-service.sh
+++ b/rabbitmq/expose/expose-service.sh
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 kubectl apply -n rabbitmq-cluster -f expose-service.yaml

--- a/rabbitmq/scripts/get-all.sh
+++ b/rabbitmq/scripts/get-all.sh
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 kubectl get all -l app.kubernetes.io/name=rabbitmqcluster-sample

--- a/rabbitmq/scripts/get-credentials.sh
+++ b/rabbitmq/scripts/get-credentials.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 kubectl get -n rabbitmq-cluster rabbitmqcluster  rabbitmqcluster-main \
 -ojsonpath='Name: {.status.admin.serviceReference.name} -- Namespace: {.status.admin.serviceReference.namespace}'
 echo  ""

--- a/scripts/doctl_setup.sh
+++ b/scripts/doctl_setup.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/sh
+
 doctl auth init
 CLUSTER=$1
 if [[ -z "$CLUSTER" ]]; then

--- a/scripts/install-latest-ansible.sh
+++ b/scripts/install-latest-ansible.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/sh
+
 sudo add-apt-repository universe
 sudo apt-get update
 sudo apt-get install libffi-dev libssl-dev software-properties-common --yes

--- a/scripts/k8s-connect-example.sh
+++ b/scripts/k8s-connect-example.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/sh
+
 doctl auth init
 doctl kubernetes cluster kubeconfig save test-k8s-treetracker
 

--- a/scripts/setup-aws-keys.sh
+++ b/scripts/setup-aws-keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/scripts/setup-production-tf-do-keys.sh
+++ b/scripts/setup-production-tf-do-keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/scripts/setup_keys.sh
+++ b/scripts/setup_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/scripts/vagrant-setup.sh
+++ b/scripts/vagrant-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 sudo apt-get update
 sudo apt-get install virtualbox -y

--- a/sealed-secrets/scripts/create-airflow-database-password-secret.sh
+++ b/sealed-secrets/scripts/create-airflow-database-password-secret.sh
@@ -1,4 +1,4 @@
-#! /bin/bash 
+#!/bin/sh 
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source ${__dir}/create-secret.sh -r airflow-database-connection -k database-password

--- a/sealed-secrets/scripts/create-aws-key-id-secret.sh
+++ b/sealed-secrets/scripts/create-aws-key-id-secret.sh
@@ -1,4 +1,4 @@
-#! /bin/bash 
+#!/bin/sh 
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source ${__dir}/create-secret.sh -r aws-key-id -k accessKeyId

--- a/sealed-secrets/scripts/create-aws-key-secret.sh
+++ b/sealed-secrets/scripts/create-aws-key-secret.sh
@@ -1,4 +1,4 @@
-#! /bin/bash 
+#!/bin/sh 
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source ${__dir}/create-secret.sh -r aws-key -k secretAccessKey

--- a/sealed-secrets/scripts/create-database-migration-secret.sh
+++ b/sealed-secrets/scripts/create-database-migration-secret.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/sh
+
 set -e
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/sealed-secrets/scripts/create-database-secret.sh
+++ b/sealed-secrets/scripts/create-database-secret.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/sh
+
 set -e
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/sealed-secrets/scripts/create-rabbitmq-secret.sh
+++ b/sealed-secrets/scripts/create-rabbitmq-secret.sh
@@ -1,4 +1,4 @@
-#! /bin/bash 
+#!/bin/sh 
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/sealed-secrets/scripts/create-secret.sh
+++ b/sealed-secrets/scripts/create-secret.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/bin/sh
+
 set -e
 
 while getopts r:k:s: flag

--- a/sealed-secrets/scripts/create-sqs-secret.sh
+++ b/sealed-secrets/scripts/create-sqs-secret.sh
@@ -1,4 +1,4 @@
-#! /bin/bash 
+#!/bin/sh 
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source ${__dir}/create-secret.sh -r sqs-url -k sqsUrl

--- a/sealed-secrets/scripts/get-database-uri.sh
+++ b/sealed-secrets/scripts/get-database-uri.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/sh
+
 set -e
 
 echo $1

--- a/tag_lister/compare.sh
+++ b/tag_lister/compare.sh
@@ -1,8 +1,9 @@
+#!/bin/sh
+
 kubectl config use-context do-sfo2-dev-k8s-treetracker
 python3 list_tags_for_deployments.py | grep treetracker > dev.out
 
 kubectl config use-context do-sfo2-test-k8s-treetracker
 python3 list_tags_for_deployments.py | grep treetracker > test.out
-
 
 vimdiff dev.out test.out

--- a/terraform/scripts/apply-dev.sh
+++ b/terraform/scripts/apply-dev.sh
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 terraform apply -var-file dev.env.tfvars

--- a/terraform/scripts/apply-prod.sh
+++ b/terraform/scripts/apply-prod.sh
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 terraform apply -var-file prod.env.tfvars

--- a/terraform/scripts/apply-test.sh
+++ b/terraform/scripts/apply-test.sh
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 terraform apply -var-file test.env.tfvars

--- a/terraform/scripts/init.sh
+++ b/terraform/scripts/init.sh
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 terraform init

--- a/terraform/scripts/plan-dev.sh
+++ b/terraform/scripts/plan-dev.sh
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 terraform plan -var-file dev.env.tfvars

--- a/terraform/scripts/plan-prod.sh
+++ b/terraform/scripts/plan-prod.sh
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 terraform plan -var-file prod.env.tfvars

--- a/terraform/scripts/plan-test.sh
+++ b/terraform/scripts/plan-test.sh
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 terraform plan -var-file test.env.tfvars

--- a/terraform/scripts/setup-aws-keys.sh
+++ b/terraform/scripts/setup-aws-keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/terraform/scripts/setup-dev-aws-keys.sh
+++ b/terraform/scripts/setup-dev-aws-keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET

--- a/terraform/scripts/setup-keys-prod.sh
+++ b/terraform/scripts/setup-keys-prod.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET


### PR DESCRIPTION
This PR is to add pre-commit hooks for shell scripts.

All shell scripts should now be marked executable and include a shebang.

I've used the following shebang for portability: `#!/bin/sh`