### PR TITLE
lock db grants tf version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,6 @@ repos:
     rev: v1.71.0
     hooks:
       - id: terraform_fmt
+      # - id: terraform_tflint
+      #   args:
+      #     - --args=--only terraform_required_version

--- a/database-grants/terraform/dev/provider.tf
+++ b/database-grants/terraform/dev/provider.tf
@@ -13,6 +13,8 @@ terraform {
       version = "1.11.0"
     }
   }
+
+  required_version = "0.14.0"
 }
 
 provider "postgresql" {

--- a/database-grants/terraform/dev/schemas/messaging/provider.tf
+++ b/database-grants/terraform/dev/schemas/messaging/provider.tf
@@ -5,4 +5,6 @@ terraform {
       version = "1.11.0"
     }
   }
+
+  required_version = "0.14.0"
 }

--- a/database-grants/terraform/prod/modules/microservice_schema/provider.tf
+++ b/database-grants/terraform/prod/modules/microservice_schema/provider.tf
@@ -5,4 +5,6 @@ terraform {
       version = "1.11.0"
     }
   }
+
+  required_version = "0.14.0"
 }

--- a/database-grants/terraform/prod/provider.tf
+++ b/database-grants/terraform/prod/provider.tf
@@ -17,6 +17,8 @@ terraform {
       version = "1.11.0"
     }
   }
+
+  required_version = "0.14.0"
 }
 
 provider "postgresql" {

--- a/database-grants/terraform/prod/schemas/airflow/provider.tf
+++ b/database-grants/terraform/prod/schemas/airflow/provider.tf
@@ -5,4 +5,6 @@ terraform {
       version = "1.11.0"
     }
   }
+
+  required_version = "0.14.0"
 }

--- a/database-grants/terraform/prod/schemas/contracts/provider.tf
+++ b/database-grants/terraform/prod/schemas/contracts/provider.tf
@@ -5,4 +5,6 @@ terraform {
       version = "1.11.0"
     }
   }
+
+  required_version = "0.14.0"
 }

--- a/database-grants/terraform/prod/schemas/earnings/provider.tf
+++ b/database-grants/terraform/prod/schemas/earnings/provider.tf
@@ -5,4 +5,6 @@ terraform {
       version = "1.11.0"
     }
   }
+
+  required_version = "0.14.0"
 }

--- a/database-grants/terraform/prod/schemas/field_data/provider.tf
+++ b/database-grants/terraform/prod/schemas/field_data/provider.tf
@@ -5,4 +5,6 @@ terraform {
       version = "1.11.0"
     }
   }
+
+  required_version = "0.14.0"
 }

--- a/database-grants/terraform/prod/schemas/messaging/provider.tf
+++ b/database-grants/terraform/prod/schemas/messaging/provider.tf
@@ -5,4 +5,6 @@ terraform {
       version = "1.11.0"
     }
   }
+
+  required_version = "0.14.0"
 }

--- a/database-grants/terraform/prod/schemas/query/provider.tf
+++ b/database-grants/terraform/prod/schemas/query/provider.tf
@@ -5,4 +5,6 @@ terraform {
       version = "1.11.0"
     }
   }
+
+  required_version = "0.14.0"
 }

--- a/database-grants/terraform/prod/schemas/regions/provider.tf
+++ b/database-grants/terraform/prod/schemas/regions/provider.tf
@@ -5,4 +5,6 @@ terraform {
       version = "1.11.0"
     }
   }
+
+  required_version = "0.14.0"
 }

--- a/database-grants/terraform/prod/schemas/reporting/provider.tf
+++ b/database-grants/terraform/prod/schemas/reporting/provider.tf
@@ -5,4 +5,6 @@ terraform {
       version = "1.11.0"
     }
   }
+
+  required_version = "0.14.0"
 }

--- a/database-grants/terraform/prod/schemas/stakeholder/provider.tf
+++ b/database-grants/terraform/prod/schemas/stakeholder/provider.tf
@@ -5,4 +5,6 @@ terraform {
       version = "1.11.0"
     }
   }
+
+  required_version = "0.14.0"
 }

--- a/database-grants/terraform/prod/schemas/treetracker/provider.tf
+++ b/database-grants/terraform/prod/schemas/treetracker/provider.tf
@@ -5,4 +5,6 @@ terraform {
       version = "1.11.0"
     }
   }
+
+  required_version = "0.14.0"
 }

--- a/database-grants/terraform/prod/schemas/wallet/provider.tf
+++ b/database-grants/terraform/prod/schemas/wallet/provider.tf
@@ -5,4 +5,6 @@ terraform {
       version = "1.11.0"
     }
   }
+
+  required_version = "0.14.0"
 }

--- a/database-grants/terraform/prod/schemas/webmap/provider.tf
+++ b/database-grants/terraform/prod/schemas/webmap/provider.tf
@@ -5,4 +5,6 @@ terraform {
       version = "1.11.0"
     }
   }
+
+  required_version = "0.14.0"
 }


### PR DESCRIPTION
This PR is to set the Terraform `required_version` attribute for `database-grants` to `0.14.0`. See issues [123](https://github.com/Greenstand/treetracker-infrastructure/issues/123) and [137](https://github.com/Greenstand/treetracker-infrastructure/issues/137).

According to TFLint, the Terraform `required_version` attribute is needed in the following places for `database-grants`:

```
database-grants/terraform/dev/
database-grants/terraform/dev/schemas/messaging/
database-grants/terraform/prod/
database-grants/terraform/prod/modules/microservice_schema/
database-grants/terraform/prod/schemas/airflow/
database-grants/terraform/prod/schemas/contracts/
database-grants/terraform/prod/schemas/earnings/
database-grants/terraform/prod/schemas/field_data/
database-grants/terraform/prod/schemas/messaging/
database-grants/terraform/prod/schemas/query/
database-grants/terraform/prod/schemas/regions/
database-grants/terraform/prod/schemas/reporting/
database-grants/terraform/prod/schemas/stakeholder/
database-grants/terraform/prod/schemas/treetracker/
database-grants/terraform/prod/schemas/wallet/
database-grants/terraform/prod/schemas/webmap/
database-grants/terraform/test/
```

Note: symlinks have been left in place.