### PR TITLE
fix db grants tf backend configs

### DIFF
--- a/database-grants/terraform/dev/backend-config.tfvars
+++ b/database-grants/terraform/dev/backend-config.tfvars
@@ -1,1 +1,0 @@
-bucket = "treetracker-dev-terraform"

--- a/database-grants/terraform/dev/backend.tf
+++ b/database-grants/terraform/dev/backend.tf
@@ -1,1 +1,17 @@
-../prod/backend.tf
+terraform {
+  # DigitalOcean uses the S3 spec.
+  backend "s3" {
+    bucket   = "treetracker-dev-terraform"
+    key      = "terraform-database-grants.tfstate"
+    endpoint = "https://sfo2.digitaloceanspaces.com"
+    # DO uses the S3 format
+    # eu-west-1 is used to pass TF validation
+    # Region is ACTUALLY sfo2 on DO
+    region = "eu-west-1"
+    # Deactivate a few checks as TF will attempt these against AWS
+    skip_credentials_validation = true
+    # skip_get_ec2_platforms = true
+    # skip_requesting_account_id = true
+    skip_metadata_api_check = true
+  }
+}

--- a/database-grants/terraform/prod/backend-config.tfvars
+++ b/database-grants/terraform/prod/backend-config.tfvars
@@ -1,1 +1,0 @@
-bucket = "treetracker-production-terraform"

--- a/database-grants/terraform/prod/backend.tf
+++ b/database-grants/terraform/prod/backend.tf
@@ -1,6 +1,7 @@
 terraform {
   # DigitalOcean uses the S3 spec.
   backend "s3" {
+    bucket   = "treetracker-production-terraform"
     key      = "terraform-database-grants.tfstate"
     endpoint = "https://sfo2.digitaloceanspaces.com"
     # DO uses the S3 format

--- a/database-grants/terraform/test/backend-config.tfvars
+++ b/database-grants/terraform/test/backend-config.tfvars
@@ -1,1 +1,0 @@
-bucket = "treetracker-test-terraform"

--- a/database-grants/terraform/test/backend.tf
+++ b/database-grants/terraform/test/backend.tf
@@ -1,1 +1,17 @@
-../prod/backend.tf
+terraform {
+  # DigitalOcean uses the S3 spec.
+  backend "s3" {
+    bucket   = "treetracker-test-terraform"
+    key      = "terraform-database-grants.tfstate"
+    endpoint = "https://sfo2.digitaloceanspaces.com"
+    # DO uses the S3 format
+    # eu-west-1 is used to pass TF validation
+    # Region is ACTUALLY sfo2 on DO
+    region = "eu-west-1"
+    # Deactivate a few checks as TF will attempt these against AWS
+    skip_credentials_validation = true
+    # skip_get_ec2_platforms = true
+    # skip_requesting_account_id = true
+    skip_metadata_api_check = true
+  }
+}


### PR DESCRIPTION
This PR addresses the first part of [this issue](https://github.com/Greenstand/treetracker-infrastructure/issues/148). 

- deleted the symlinks from dev and test to prod backend.tf
- copied prod backend.tf file to dev and test
- added the bucket names to backend.tf files for dev, test, and prod
- deleted the backend-config.tvars files in dev, test, and prod