### PR TITLE
fix kubernetes tf backend configs

### DIFF
--- a/kubernetes/terraform/dev/backend-config.tfvars
+++ b/kubernetes/terraform/dev/backend-config.tfvars
@@ -1,1 +1,0 @@
-bucket = "treetracker-dev-terraform"

--- a/kubernetes/terraform/dev/backend.tf
+++ b/kubernetes/terraform/dev/backend.tf
@@ -2,7 +2,7 @@
 terraform {
   # DigitalOcean uses the S3 spec.
   backend "s3" {
-    # bucket = provided by backend-config.tfvars
+    bucket   = "treetracker-dev-terraform"
     key      = "terraform-kubernetes.tfstate"
     endpoint = "https://sfo2.digitaloceanspaces.com"
     # DO uses the S3 format

--- a/kubernetes/terraform/prod/backend-config.tfvars
+++ b/kubernetes/terraform/prod/backend-config.tfvars
@@ -1,1 +1,0 @@
-bucket = "treetracker-production-terraform"

--- a/kubernetes/terraform/prod/backend.tf
+++ b/kubernetes/terraform/prod/backend.tf
@@ -2,7 +2,7 @@
 terraform {
   # DigitalOcean uses the S3 spec.
   backend "s3" {
-    # bucket = provided by backend-config.tfvars
+    bucket   = "treetracker-production-terraform"
     key      = "terraform-kubernetes.tfstate"
     endpoint = "https://sfo2.digitaloceanspaces.com"
     # DO uses the S3 format

--- a/kubernetes/terraform/test/backend-config.tfvars
+++ b/kubernetes/terraform/test/backend-config.tfvars
@@ -1,1 +1,0 @@
-bucket = "treetracker-test-terraform"

--- a/kubernetes/terraform/test/backend.tf
+++ b/kubernetes/terraform/test/backend.tf
@@ -1,1 +1,18 @@
-../dev/backend.tf
+
+terraform {
+  # DigitalOcean uses the S3 spec.
+  backend "s3" {
+    bucket   = "treetracker-test-terraform"
+    key      = "terraform-kubernetes.tfstate"
+    endpoint = "https://sfo2.digitaloceanspaces.com"
+    # DO uses the S3 format
+    # eu-west-1 is used to pass TF validation
+    # Region is ACTUALLY sfo2 on DO
+    region = "eu-west-1"
+    # Deactivate a few checks as TF will attempt these against AWS
+    skip_credentials_validation = true
+    # skip_get_ec2_platforms = true
+    # skip_requesting_account_id = true
+    skip_metadata_api_check = true
+  }
+}


### PR DESCRIPTION
This PR addresses the second part of [this issue](https://github.com/Greenstand/treetracker-infrastructure/issues/148).

- deleted the symlink from test to dev backend.tf (dev and prod have their own backend.tf files)
- copied prod backend.tf file to test (dev already has its own matching backend.tf file)
- added the bucket names to backend.tf files for dev, test, and prod
- deleted the backend-config.tvars files in dev, test, and prod