### PR TITLE
feat: lock terraform version to 1.4.6

### DIFF
--- a/database-grants/terraform/README.md
+++ b/database-grants/terraform/README.md
@@ -31,8 +31,10 @@ Use correct version:
 ```bash
 tfenv use min-required
 ```
-OR 
+OR if you configure `.terraform-version`
+
 ```bash
+echo "1.4.6" > .terraform-version
 tfenv use # this will configure the correct version from .terraform-version file
 ```
 

--- a/database-grants/terraform/README.md
+++ b/database-grants/terraform/README.md
@@ -1,6 +1,11 @@
 # Prerequisites
 
-- Terraform 1.4.6 , please stick to this version for now, tested 1.6.x, it brings issue with the Dititalocean storage as backend
+- Ensure you have `tfenv` installed in your system. https://github.com/tfutils/tfenv
+
+- The terraform configuration in this directory requires to have `terraform` binary version to be minimum 1.4.6 Ref: https://developer.hashicorp.com/terraform/tutorials/configuration-language/versions#review-example-configuration
+
+  
+
 
 
 # How to set up terraform
@@ -21,6 +26,19 @@ source setup_keys.sh
 ```
 
 # How to run terraform
+
+Use correct version:
+```bash
+tfenv use min-required
+```
+OR 
+```bash
+tfenv use # this will configure the correct version from .terraform-version file
+```
+
+```bash
+terraform version # check if the version matches with the required_version in provider.tf
+```
 
 Init:
 

--- a/database-grants/terraform/dev/provider.tf
+++ b/database-grants/terraform/dev/provider.tf
@@ -7,6 +7,9 @@ variable "password" {
 }
 
 terraform {
+  # Ref: https://developer.hashicorp.com/terraform/tutorials/configuration-language/versions#review-example-configuration 
+  required_version = "~> 1.4.6"  
+
   required_providers {
     postgresql = {
       source  = "cyrilgdn/postgresql"

--- a/database-grants/terraform/dev/provider.tf
+++ b/database-grants/terraform/dev/provider.tf
@@ -8,7 +8,7 @@ variable "password" {
 
 terraform {
   # Ref: https://developer.hashicorp.com/terraform/tutorials/configuration-language/versions#review-example-configuration 
-  required_version = "~> 1.4.6"  
+  required_version = "~> 1.4.6"
 
   required_providers {
     postgresql = {

--- a/database-grants/terraform/dev/setup_keys.sh
+++ b/database-grants/terraform/dev/setup_keys.sh
@@ -3,9 +3,6 @@
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET
 # Source this file before running terraform commands
-
-grep_string=$(cat backend.tf | grep endpoint | awk -F'=' '{print $2}' | awk -F'/' '{print $NF}' | sed 's/"//g')
-
-netrc_string=$(grep ${grep_string} ~/.netrc)
+netrc_string=$(grep digitalocean.dev.treetracker.org ~/.netrc)
 export AWS_ACCESS_KEY_ID=$(echo $netrc_string | awk '{print $4}')
 export AWS_SECRET_ACCESS_KEY=$(echo $netrc_string | awk '{print $6}')

--- a/database-grants/terraform/dev/setup_keys.sh
+++ b/database-grants/terraform/dev/setup_keys.sh
@@ -3,6 +3,9 @@
 # Retrieve keys from your netrc, specified as
 # machine sfo2.digitaloceanspaces.com login KEY password SECRET
 # Source this file before running terraform commands
-netrc_string=$(grep digitalocean.dev.treetracker.org ~/.netrc)
+
+grep_string=$(cat backend.tf | grep endpoint | awk -F'=' '{print $2}' | awk -F'/' '{print $NF}' | sed 's/"//g')
+
+netrc_string=$(grep ${grep_string} ~/.netrc)
 export AWS_ACCESS_KEY_ID=$(echo $netrc_string | awk '{print $4}')
 export AWS_SECRET_ACCESS_KEY=$(echo $netrc_string | awk '{print $6}')

--- a/database-grants/terraform/prod/backend.tf
+++ b/database-grants/terraform/prod/backend.tf
@@ -11,6 +11,6 @@ terraform {
     skip_credentials_validation = true
     # skip_get_ec2_platforms = true
     skip_requesting_account_id = true
-    skip_metadata_api_check = true
+    skip_metadata_api_check    = true
   }
 }


### PR DESCRIPTION
Changes as below:
- added steps to use `tfenv` to the README.md
- added .terraform-version which acts as a configuration file for `tfenv`
- added `required_version` in provider.tf to use terraform version 1.4.6 ; reference: https://developer.hashicorp.com/terraform/tutorials/configuration-language/versions#review-example-configuration
- update setup_keys.sh script 

To Do: 
- currently all the above changes are only made to the dev folder, same needs to be replicated to the other envs.

```bash
❯ terraform version
Terraform v1.7.0
on darwin_amd64
+ provider registry.terraform.io/cyrilgdn/postgresql v1.11.0
+ provider registry.terraform.io/hashicorp/random v3.6.0

Your version of Terraform is out of date! The latest version
is 1.7.4. You can update by downloading from https://www.terraform.io/downloads.html


# If incorrect version is used terraform init command will fail with below error: 
❯ terraform init -backend-config=backend-config.tfvars

Initializing the backend...
Initializing modules...
╷
│ Error: Unsupported Terraform Core version
│
│   on provider.tf line 11, in terraform:
│   11:   required_version = "~> 1.4.6"
│
│ This configuration does not support Terraform version 1.7.0. To proceed, either choose another supported Terraform version or update this version constraint. Version constraints are
│ normally set for good reason, so updating the constraint may lead to other errors or unexpected behavior.
╵




# .terraform-version file will not allow to use incorrect version as seen below
❯ tfenv use 1.7.0
Switching default version to v1.7.0
Default version file overridden by /gs/treetracker-infrastructure/database-grants/terraform/dev/.terraform-version, changing the default version has no effect
Default version (when not overridden by .terraform-version or TFENV_TERRAFORM_VERSION) is now: 1.7.0




```
