### PR TITLE
fix: expand .gitignore to cover all .tfvars files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *playbook.retry
 .DS_Store
+*.tfvars
 terraform.tfvars
 .terraform*
 *.swp


### PR DESCRIPTION
## What
Adds `*.tfvars` wildcard to `.gitignore`, alongside the existing `terraform.tfvars` entry.

## Why
The current `.gitignore` only excludes `terraform.tfvars` — the default Terraform variable file. Any environment-specific variable files following common naming conventions (e.g. `prod.tfvars`, `staging.tfvars`, `secrets.tfvars`) are not covered and would be committed unintentionally.

`.tfvars` files frequently contain database passwords, API keys, and other credentials. A single missed filename is enough for a secret to land in git history.

This is a partial hardening step toward the broader secrets management work tracked in #213.