### PR TITLE
fix: remove unused treetracker database schemas

### DIFF
--- a/database-grants/terraform/dev/main.tf
+++ b/database-grants/terraform/dev/main.tf
@@ -12,12 +12,6 @@ module "treetracker_schema" {
   }
 }
 
-module "webmap_schema" {
-  source = "./schemas/webmap"
-  providers = {
-    postgresql = postgresql.treetracker
-  }
-}
 
 module "stakeholder_schema" {
   source = "./schemas/stakeholder"
@@ -33,12 +27,6 @@ module "earnings_schema" {
   }
 }
 
-module "regions_schema" {
-  source = "./schemas/regions"
-  providers = {
-    postgresql = postgresql.treetracker
-  }
-}
 
 module "messaging_schema" {
   source = "./schemas/messaging"
@@ -68,12 +56,6 @@ module "reporting_schema" {
   }
 }
 
-module "contracts_schema" {
-  source = "./schemas/contracts"
-  providers = {
-    postgresql = postgresql.treetracker
-  }
-}
 
 module "keycloak_schema" {
   source = "./schemas/keycloak"

--- a/database-grants/terraform/dev/schemas/contracts
+++ b/database-grants/terraform/dev/schemas/contracts
@@ -1,1 +1,0 @@
-../../prod/schemas/contracts/

--- a/database-grants/terraform/dev/schemas/regions
+++ b/database-grants/terraform/dev/schemas/regions
@@ -1,1 +1,0 @@
-../../prod/schemas/regions/

--- a/database-grants/terraform/dev/schemas/webmap
+++ b/database-grants/terraform/dev/schemas/webmap
@@ -1,1 +1,0 @@
-../../prod/schemas/webmap/

--- a/database-grants/terraform/prod/main.tf
+++ b/database-grants/terraform/prod/main.tf
@@ -28,12 +28,6 @@ module "earnings_schema" {
   }
 }
 
-module "webmap_schema" {
-  source = "./schemas/webmap"
-  providers = {
-    postgresql = postgresql.treetracker
-  }
-}
 
 module "reporting_schema" {
   source = "./schemas/reporting"
@@ -70,19 +64,7 @@ module "stakeholder_schema" {
   }
 }
 
-module "regions_schema" {
-  source = "./schemas/regions"
-  providers = {
-    postgresql = postgresql.treetracker
-  }
-}
 
-module "contracts_schema" {
-  source = "./schemas/contracts"
-  providers = {
-    postgresql = postgresql.treetracker
-  }
-}
 
 module "keycloak_schema" {
   source = "./schemas/keycloak"

--- a/database-grants/terraform/prod/read-only-user.tf
+++ b/database-grants/terraform/prod/read-only-user.tf
@@ -164,23 +164,6 @@ resource "postgresql_grant" "readonlyyuser_sequence_wallet" {
   privileges  = ["SELECT", "USAGE"]
 }
 
-resource "postgresql_grant" "readonlyyuser_usage_webmap" {
-  provider    = "postgresql.treetracker"
-  database    = "treetracker"
-  role        = "readonlyuser"
-  schema      = "webmap"
-  object_type = "schema"
-  privileges  = ["USAGE"]
-}
-
-resource "postgresql_grant" "readonlyyuser_sequence_webmap" {
-  provider    = "postgresql.treetracker"
-  database    = "treetracker"
-  role        = "readonlyuser"
-  schema      = "webmap"
-  object_type = "sequence"
-  privileges  = ["SELECT", "USAGE"]
-}
 
 resource "postgresql_grant" "readonlyyuser_usage_airflow" {
   provider    = "postgresql.treetracker"

--- a/database-grants/terraform/prod/schemas/contracts/main.tf
+++ b/database-grants/terraform/prod/schemas/contracts/main.tf
@@ -1,7 +1,0 @@
-
-module "microservice_schema" {
-  source = "./../../modules/microservice_schema"
-  schema = "contracts"
-}
-
-

--- a/database-grants/terraform/prod/schemas/contracts/provider.tf
+++ b/database-grants/terraform/prod/schemas/contracts/provider.tf
@@ -1,8 +1,0 @@
-terraform {
-  required_providers {
-    postgresql = {
-      source  = "cyrilgdn/postgresql"
-      version = "1.22.0"
-    }
-  }
-}

--- a/database-grants/terraform/prod/schemas/query/main.tf
+++ b/database-grants/terraform/prod/schemas/query/main.tf
@@ -52,21 +52,7 @@ resource "postgresql_grant" "query_stakeholder_tables" {
   privileges  = ["SELECT"]
 }
 
-resource "postgresql_grant" "query_regions_schema" {
-  database    = "treetracker"
-  role        = "s_query"
-  schema      = "regions"
-  object_type = "schema"
-  privileges  = ["USAGE"]
-}
 
-resource "postgresql_grant" "query_regions_tables" {
-  database    = "treetracker"
-  role        = "s_query"
-  schema      = "regions"
-  object_type = "table"
-  privileges  = ["SELECT"]
-}
 
 resource "postgresql_grant" "query_public_schema" {
   database    = "treetracker"

--- a/database-grants/terraform/prod/schemas/regions/main.tf
+++ b/database-grants/terraform/prod/schemas/regions/main.tf
@@ -1,7 +1,0 @@
-
-module "microservice_schema" {
-  source = "./../../modules/microservice_schema"
-  schema = "regions"
-}
-
-

--- a/database-grants/terraform/prod/schemas/regions/provider.tf
+++ b/database-grants/terraform/prod/schemas/regions/provider.tf
@@ -1,8 +1,0 @@
-terraform {
-  required_providers {
-    postgresql = {
-      source  = "cyrilgdn/postgresql"
-      version = "1.22.0"
-    }
-  }
-}

--- a/database-grants/terraform/prod/schemas/webmap/main.tf
+++ b/database-grants/terraform/prod/schemas/webmap/main.tf
@@ -1,7 +1,0 @@
-
-module "microservice_schema" {
-  source = "./../../modules/microservice_schema"
-  schema = "webmap"
-}
-
-

--- a/database-grants/terraform/prod/schemas/webmap/provider.tf
+++ b/database-grants/terraform/prod/schemas/webmap/provider.tf
@@ -1,8 +1,0 @@
-terraform {
-  required_providers {
-    postgresql = {
-      source  = "cyrilgdn/postgresql"
-      version = "1.22.0"
-    }
-  }
-}


### PR DESCRIPTION
## Summary

Removed unused database schema infrastructure related to the services listed in issue #311:

- treetracker region api
- treetracker contract api
- treetracker web map api

## Changes

- Removed `regions`, `contracts`, and `webmap` schema modules from dev and prod database-grants Terraform.
- Removed related production schema grant resources.
- Deleted unused schema module files/folders.

## Validation

- Confirmed no remaining active references to:
  - `webmap_schema`
  - `regions_schema`
  - `contracts_schema`
  - `schema = "webmap"`
  - `schema = "regions"`
  - `schema = "contracts"`

Note: Terraform CLI was not installed locally, so `terraform fmt -recursive` could not be run.

Closes #311