### PR TITLE
fix: scale down rabbitmq replicas

### DIFF
--- a/rabbitmq/deployment/base/definition.yaml
+++ b/rabbitmq/deployment/base/definition.yaml
@@ -3,7 +3,7 @@ kind: RabbitmqCluster
 metadata:
   name: rabbitmqcluster-main
 spec:
-  replicas: 3
+  replicas: 1
   resources: #these are the defaults
     requests:
       cpu: 1000m


### PR DESCRIPTION
## Summary

Updated RabbitMQ deployment manifest to scale the cluster down to a single replica for issue #310.

## Changes

- Changed `rabbitmq/deployment/base/definition.yaml` from `replicas: 3` to `replicas: 1`.
- Confirmed production overlay uses the base manifest.
- Confirmed dev overlay already patches RabbitMQ to `replicas: 1`.

## Validation

- Ran `grep -Rni "replicas:" rabbitmq/deployment --exclude-dir=.git`
- Confirmed both relevant RabbitMQ replica definitions are set to `1`.

Closes #310